### PR TITLE
Enable web view to support pinch-to-zoom

### DIFF
--- a/ADAL/src/ui/ios/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/ios/ADAuthenticationViewController.m
@@ -80,6 +80,7 @@ NSString *const AD_FAILED_NO_CONTROLLER = @"The Application does not have a curr
     [rootView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
     UIWebView* webView = [[UIWebView alloc] initWithFrame:rootView.frame];
     [webView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
+    [webView setScalesPageToFit:YES];
     [webView setDelegate:self];
     [rootView addSubview:webView];
     _webView = webView;


### PR DESCRIPTION
Azure AD production team and MSIT team have fixed the accessibility
issue for the ADFS login webpage to support pin-to-zoom. However, the
issue still exists on iPhone. This change will address the issue on
iOS.
